### PR TITLE
[DOC]: Manual Installation of Nilearn

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dockerhub (preferred):
 docker pull dpys/pynets:latest
 ```
 
-Manual (Requires a local dependency install of FSL version >=5.0.9):
+Manual (Requires a local dependency install of FSL version >=5.0.9 and Nilearn version >=0.7.0a):
 ```
 pip install pynets
 ```


### PR DESCRIPTION
The current version of PyNets needs Nilearn to be installed from source. 

A simple `pip install pynets` won't work unless this is explicitly done.