### PR TITLE
[WIP] Reporting - Plotly

### DIFF
--- a/pynets/reports/plotting.py
+++ b/pynets/reports/plotting.py
@@ -1,0 +1,58 @@
+"""Plotting functions to embed into html reports."""
+
+import nibabel as nib
+import os
+import numpy as np
+import plotly.graph_objs as go
+from plotly.subplots import make_subplots
+
+
+def plot_t1w(t1w):
+    """Plot t1w images using plotly.
+
+    Parameters
+    ----------
+    t1w : str
+        Path to a t1w image.
+
+    Returns
+    -------
+    fig : plotly.graph_objs.Figure
+        A plotly figure that is ready-to-embed using the to_html method.
+    """
+
+    # Load data from file
+    t1w_arr = nib.load(t1w).get_fdata()
+
+    # Space out z-slices
+    z_max = np.shape(t1w_arr)[2]
+    pad = 30
+    z_slices = np.linspace(pad, z_max-pad, num=21, dtype=int)
+
+    # Init figure
+    nrows = 3
+    ncols = 7
+    fig = make_subplots(nrows, ncols, vertical_spacing=0.005, horizontal_spacing=0.005)
+
+    # Get subplot positions
+    fig_idxs = [(row, col) for row in range(1, nrows+1)
+                for col in range(1, ncols+1)]
+
+    for idx, z_slice in enumerate(z_slices):
+
+        # Slice and rotate the t1w array
+        img_slice = np.rot90(t1w_arr[:, :, z_slice], k=3)
+
+        # Get subplot coords
+        x_coord, y_coord = fig_idxs[idx]
+
+        fig.add_trace(go.Heatmap(z=img_slice, showscale=False, colorscale="gray"),
+                      x_coord, y_coord)
+
+        # Update axes
+        fig.update_xaxes(showticklabels=False, row=x_coord, col=y_coord)
+        fig.update_yaxes(showticklabels=False, row=x_coord, col=y_coord)
+
+    fig.update_layout(width=800, height=500)
+
+    return fig

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ git+https://github.com/dPys/nilearn.git@enh/parc_conn
 git+https://github.com/dPys/deepbrain.git@master
 urllib3>=1.25.4
 mplcyberpunk>=0.1.11
+plotly>=4.14.1


### PR DESCRIPTION
There is still a lot to-do on this, but it's a start. This uses plotly to create figures, which can then easily be embedded into html reports using to `to_html` method.

```python
from pynets.reports.plotting import plot_t1w

# Load the data from register_node
cwd = os.getcwd()
reg_dir = os.path.join(cwd, 'data/register_node')
t1w_path = os.path.join(reg_dir, 'sub-OAS31172_ses-d0407_run-01_T1w_reor-RAS_res-2mm_tmp.nii.gz')

# Plot
fig = plot_t1w(t1w_path)
fig.show()

# Create an html page
html = fig.to_html()

with open('test.html', 'w') as f:
    f.write(html)
```

This produces simple axial slice plots similar to fmriprep. Plotly is super cool and can also do things like animations - which could be useful for checking registration - with a relatively small amount of code. 

To-Do List:
- Create general report templates to drop figures into
- Extend plotting funcs to fMRI, dMRI, segmentation overlays, graphs, etc
- Testing

![newplot](https://user-images.githubusercontent.com/34786005/103726612-377fba00-4f8e-11eb-95fe-bbae9e0a914c.png)

Anyone can directly push here as well. I'll likely be slow, so don't let me bottleneck things.